### PR TITLE
Fix schema path/id and make schemas translatable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,8 @@
-gsettings_SCHEMAS = org.mate.caja-open-terminal.gschema.xml
+gsettings_schemas_in_files = org.mate.caja-open-terminal.gschema.xml.in
+gsettings_SCHEMAS = $(gsettings_schemas_in_files:.gschema.xml.in=.gschema.xml)
+
+@INTLTOOL_XML_NOMERGE_RULE@
+
 @GSETTINGS_RULES@
 
 SUBDIRS = \
@@ -8,11 +12,12 @@ SUBDIRS = \
 EXTRA_DIST = \
 	intltool-extract.in \
 	intltool-update.in \
-	intltool-merge.in
+	intltool-merge.in \
+	$(gsettings_schemas_in_files)
 
 DISTCLEANFILES = \
 	intltool-extract \
 	intltool-update \
 	intltool-merge \
-	po/.intltool-merge-cache
-
+	po/.intltool-merge-cache \
+	org.mate.caja-open-terminal.gschema.xml

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-gsettings_SCHEMAS = org.mate.apps.caja-open-terminal.gschema.xml
+gsettings_SCHEMAS = org.mate.caja-open-terminal.gschema.xml
 @GSETTINGS_RULES@
 
 SUBDIRS = \

--- a/configure.in
+++ b/configure.in
@@ -46,8 +46,6 @@ dnl Get caja extensions directory
 CAJA_EXTENSION_DIR=`$PKG_CONFIG --variable=extensiondir libcaja-extension`
 AC_SUBST(CAJA_EXTENSION_DIR)
 
-dnl MateConf
-
 dnl intltool stuff
 AC_PROG_INTLTOOL(0.18)
 dnl AM_WITH_NLS

--- a/org.mate.caja-open-terminal.gschema.xml
+++ b/org.mate.caja-open-terminal.gschema.xml
@@ -1,9 +1,0 @@
-<schemalist>
-  <schema id="org.mate.caja-open-terminal" path="/org/mate/caja-open-terminal/">
-    <key name="desktop-opens-home-dir" type="b">
-      <default>false</default>
-      <summary>Whether opening a terminal on the desktop opens a terminal in the home directory</summary>
-      <description>If set to true, then opening a terminal on the desktop will open a terminal in the home directory. Otherwise, it will be opened in the desktop directory. Note that this key is irrelevant if the desktop directory is identical to the home directory.</description>
-    </key>
-  </schema>
-</schemalist>

--- a/org.mate.caja-open-terminal.gschema.xml
+++ b/org.mate.caja-open-terminal.gschema.xml
@@ -1,5 +1,5 @@
 <schemalist>
-  <schema id="org.mate.apps.caja-open-terminal" path="/apps/caja-open-terminal/">
+  <schema id="org.mate.caja-open-terminal" path="/org/mate/caja-open-terminal/">
     <key name="desktop-opens-home-dir" type="b">
       <default>false</default>
       <summary>Whether opening a terminal on the desktop opens a terminal in the home directory</summary>

--- a/org.mate.caja-open-terminal.gschema.xml.in
+++ b/org.mate.caja-open-terminal.gschema.xml.in
@@ -1,0 +1,9 @@
+<schemalist>
+  <schema id="org.mate.caja-open-terminal" path="/org/mate/caja-open-terminal/">
+    <key name="desktop-opens-home-dir" type="b">
+      <default>false</default>
+      <_summary>Whether opening a terminal on the desktop opens a terminal in the home directory</_summary>
+      <_description>If set to true, then opening a terminal on the desktop will open a terminal in the home directory. Otherwise, it will be opened in the desktop directory. Note that this key is irrelevant if the desktop directory is identical to the home directory.</_description>
+    </key>
+  </schema>
+</schemalist>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,4 @@
 # List of source files containing translatable strings.
 # Please keep this list in alphabetic order.
-org.mate.caja-open-terminal.gschema.xml
+org.mate.caja-open-terminal.gschema.xml.in
 src/caja-open-terminal.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,4 @@
 # List of source files containing translatable strings.
 # Please keep this list in alphabetic order.
+org.mate.caja-open-terminal.gschema.xml
 src/caja-open-terminal.c
-caja-open-terminal.schemas.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,6 @@ INCLUDES =						\
 	$(WARN_CFLAGS)                                  \
 	$(DISABLE_DEPRECATED_CFLAGS)			\
 	$(CAJA_CFLAGS)				\
-	$(MATECONF_CFLAGS)					\
 	$(MATEDESKTOP_CFLAGS)
 
 caja_extensiondir=$(CAJA_EXTENSION_DIR)
@@ -20,4 +19,4 @@ libcaja_open_terminal_la_SOURCES = \
 	open-terminal.c
 
 libcaja_open_terminal_la_LDFLAGS = -module -avoid-version
-libcaja_open_terminal_la_LIBADD  = $(CAJA_LIBS) $(MATEVFS_LIBS) $(MATECONF_LIBS) $(MATEDESKTOP_LIBS)
+libcaja_open_terminal_la_LIBADD  = $(CAJA_LIBS) $(MATEDESKTOP_LIBS)

--- a/src/caja-open-terminal.c
+++ b/src/caja-open-terminal.c
@@ -45,7 +45,7 @@
 #include <sys/stat.h>
 
 #define SSH_DEFAULT_PORT 22
-#define COT_SCHEMA "org.mate.apps.caja-open-terminal"
+#define COT_SCHEMA "org.mate.caja-open-terminal"
 #define COT_DESKTOP_KEY "desktop-opens-home-dir"
 #define CAJA_SCHEMA "org.mate.caja.preferences"
 #define CAJA_DESKTOP_KEY "desktop-is-home-dir"


### PR DESCRIPTION
This changes org.mate.apps.caja-open-terminal to org.mate.caja-open-terminal and uses /org/mate/caja-open-terminal as the schema path. I also made the gschema translatable and removed a few old mateconf cflags.
